### PR TITLE
Use response.json() instead of response.json

### DIFF
--- a/hoiio/service/__init__.py
+++ b/hoiio/service/__init__.py
@@ -60,11 +60,11 @@ class Response:
         response is from Requests
         """
         self.response = response
-        self.json = response.json
+        self.json = response.json()
         self.text = response.text
         try:
-            for key in response.json:
-                value = response.json[key]
+            for key in response.json():
+                value = response.json()[key]
                 setattr(self, key, sanitize(key, value))
 
         except Exception, e:


### PR DESCRIPTION
Seems that at least for requests==2.4.3, `response.json` has become `response.json()`

Making the change to a method call avoids a HoiioException being raised when creating a Response object
